### PR TITLE
[packages/mlt] compress lumas.

### DIFF
--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -8,7 +8,7 @@
 
 pkgname=mlt
 pkgver=6.22.0
-pkgrel=1
+pkgrel=2
 pkgdesc="An open source multimedia framework"
 arch=(x86_64)
 url="https://www.mltframework.org"
@@ -32,7 +32,7 @@ optdepends=('sdl_image: SDL1 plugin'
         'pango: gdk plugin'
         'rtaudio: rtaudio plugin'
         'python: python bindings')
-makedepends=(cmake ladspa frei0r-plugins libdv sdl_image libsamplerate sox ffmpeg vid.stab qt5-svg
+makedepends=(cmake imagemagick ladspa frei0r-plugins libdv sdl_image libsamplerate sox ffmpeg vid.stab qt5-svg
              jack libexif python swig movit eigen opencv rubberband gdk-pixbuf2 pango rtaudio)
 conflicts=(python-mlt)
 provides=(python-mlt)
@@ -68,4 +68,10 @@ package() {
   mkdir -p "$pkgdir/$_pythonpath"
   install -m755 mlt.py "$pkgdir/$_pythonpath" 
   install -m755 _mlt.so "$pkgdir/$_pythonpath"
+
+# Compress lumas
+  for pgm in ${pkgdir}/usr/share/${pkgname}/lumas/*/luma*pgm; do
+    convert $pgm ${pgm}.png
+    rm -f $pgm
+  done
 }


### PR DESCRIPTION
After switching to cmake `mlt` balloons out substantially (from `3MiB` to `260MiB`) by generating uncompressed lumas for for `luma_transition_filter.

[There's no flag in `cmake` to turn off lumas build or to build compressed lumas](https://github.com/mltframework/mlt/commit/b9732158e5c8446d5083adcc5586c6938f8b75a1#diff-cb48c84f4672eeab94c4f8908b424727) (those options exists only in `configure/make` build)
I propose using [a bit of code of code form `/mlt/src/module/lumas/create_lumas.sh` to compress lumas from `pgm`s to `png`s](https://github.com/mltframework/mlt/blob/master/src/modules/lumas/create_lumas#L68-L73).

This way we go down with `mlt` size form `~260MiB` to `8.7MiB`
