### PR TITLE
Update PKGBUILD (add --with-versioned-syms)

### DIFF
--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -43,7 +43,8 @@ build() {
     --enable-pc-files \
     --with-cxx-binding \
     --with-cxx-shared \
-    --with-manpage-format=normal
+    --with-manpage-format=normal \
+    --with-versioned-syms
   make
 }
 


### PR DESCRIPTION
To solve “/usr/lib/libtinfo.so.6: no version information available” issue