### PR TITLE
imagemagick as optional dep on kile

### DIFF
--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -10,7 +10,8 @@ license=(GPL2)
 url="https://kile.sourceforge.io"
 depends=(ktexteditor kinit okular khtml texlive-core qt5-script)
 makedepends=(extra-cmake-modules kdoctools)
-optdepends=('konsole: embedded terminal')
+optdepends=('konsole: embedded terminal'
+            'imagemagick: convert support')
 source=("https://downloads.sourceforge.net/$pkgname/$pkgname-$pkgver.tar.bz2")
 sha256sums=('04499212ffcb24fb3a6829149a7cae4c6ad5d795985f080800d6df72f88c5df0')
 


### PR DESCRIPTION
I think imagemagick should be flagged as optional deps for "convert" support inside the program, otherwise manually installing imagemagick as deps left the package orphan