### PR TITLE
makepkg needs binutils and fakeroot

### DIFF
--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -9,7 +9,7 @@ arch=('x86_64')
 url="https://www.archlinux.org/pacman/"
 license=('GPL')
 groups=('base-devel')
-depends=('bash' 'glibc' 'libarchive' 'curl'
+depends=('bash' 'glibc' 'libarchive' 'curl' 'fakeroot' 'binutils'
          'gpgme' 'pacman-mirrorlist' 'archlinux-keyring')
 makedepends=('meson' 'asciidoc' 'doxygen')
 checkdepends=('python' 'fakechroot')


### PR DESCRIPTION
"Stripping unneeded symbols from binaries and libraries" will fail without `binutils`
"Entering fakeroot environment" will fail without `fakeroot`