### PR TITLE
Missing `/etc/initrd-release`

### DIFF
--- a/trunk/initcpio-install-systemd
+++ b/trunk/initcpio-install-systemd
@@ -137,6 +137,9 @@ build() {
       set -f
       printf '%s\n' ${MODULES[@]} >"$BUILDROOT/etc/modules-load.d/MODULES.conf"
     )
+    
+    add_file "/usr/lib/os-release" "/usr/lib/initrd-release"
+    add_symlink "/etc/initrd-release" "../usr/lib/initrd-release"
 }
 
 help() {


### PR DESCRIPTION
The [documentation](https://www.freedesktop.org/software/systemd/man/bootup.html#Bootup%20in%20the%20Initial%20RAM%20Disk%20(initrd)) indicates systemd running in initramfs mode requires `/etc/initrd-release`