### PR TITLE
Add resolve_btfids to linux headers package

### DIFF
--- a/linux/trunk/PKGBUILD
+++ b/linux/trunk/PKGBUILD
@@ -107,6 +107,9 @@ _package-headers() {
 
   # add objtool for external module building and enabled VALIDATION_STACK option
   install -Dt "$builddir/tools/objtool" tools/objtool/objtool
+  
+  # add resolve_btfids for external module building and enabled BPF options
+  install -Dt "$builddir/tools/bpf/resolve_btfids" tools/bpf/resolve_btfids/resolve_btfids
 
   # add xfs and shmem for aufs building
   mkdir -p "$builddir"/{fs/xfs,mm}


### PR DESCRIPTION
Some kernel modules, like https://github.com/aircrack-ng/rtl8812au/, require resolve_btfids on recent kernels