### PR TITLE
Use system libfdt

### DIFF
--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -183,6 +183,7 @@ build() {
       --libexecdir=/usr/lib/qemu \
       --localstatedir=/var \
       --docdir=/usr/share/doc/qemu \
+      --enable-fdt=system \
       --enable-modules \
       --enable-sdl \
       --enable-slirp=system \


### PR DESCRIPTION
qemu package already depends on dtc. So make use of system-libfdt, too.