### PR TITLE
samba official download site instead of US mirror

### DIFF
--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -10,7 +10,7 @@
 pkgbase=samba
 pkgname=('libwbclient' 'smbclient' 'samba')
 pkgver=4.18.0
-pkgrel=2
+pkgrel=3
 arch=(x86_64)
 url="https://www.samba.org"
 license=('GPL3')
@@ -24,7 +24,7 @@ optdepends=(
              'python-markdown: for samba-tool domain schemeupgrade'
              'glusterfs: for vfs_glusterfs support'
 )
-source=(https://us1.samba.org/samba/ftp/stable/${pkgbase}-${pkgver}.tar{.gz,.asc}
+source=(https://download.samba.org/samba/ftp/stable/${pkgbase}-${pkgver}.tar{.gz,.asc}
         samba.logrotate
         samba.pam
         samba.conf)


### PR DESCRIPTION
https://us1.samba.org/samba/ftp/stable/samba-4.18.0.tar.gz https://www.samba.org/samba/download/
https://download.samba.org/samba/ftp/stable/samba-4.18.0.tar.gz

us1 mirror doesn't work outside the US

Gitlab will not allow me to sign in without a phone